### PR TITLE
fix order types

### DIFF
--- a/src/main/kotlin/payload/response/ItemOrders.kt
+++ b/src/main/kotlin/payload/response/ItemOrders.kt
@@ -1,9 +1,9 @@
 package payload.response
 
 import kotlinx.serialization.Serializable
-import payload.response.common.Order
+import payload.response.common.OrderFromItem
 
 @Serializable
 data class ItemOrders private constructor(
-	val orders: List<Order>
+	val orders: List<OrderFromItem>
 )

--- a/src/main/kotlin/payload/response/ItemOrdersTop.kt
+++ b/src/main/kotlin/payload/response/ItemOrdersTop.kt
@@ -1,10 +1,10 @@
 package payload.response
 
-import payload.response.common.Order
+import payload.response.common.OrderFromItem
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class ItemOrdersTop private constructor(
-	val sell_orders: List<Order>,
-	val buy_orders: List<Order>
+	val sell_orders: List<OrderFromItem>,
+	val buy_orders: List<OrderFromItem>
 )

--- a/src/main/kotlin/payload/response/OrderClosed.kt
+++ b/src/main/kotlin/payload/response/OrderClosed.kt
@@ -1,9 +1,9 @@
 package payload.response
 
-import payload.response.common.Order
 import kotlinx.serialization.Serializable
+import payload.response.common.OrderFromClosure
 
 @Serializable
 data class OrderClosed private constructor(
-	val order: Order?
+	val order: OrderFromClosure?
 )

--- a/src/main/kotlin/payload/response/OrderCreated.kt
+++ b/src/main/kotlin/payload/response/OrderCreated.kt
@@ -1,9 +1,9 @@
 package payload.response
 
-import payload.response.common.Order
 import kotlinx.serialization.Serializable
+import payload.response.common.*
 
 @Serializable
 data class OrderCreated private constructor(
-	val order: Order
+	val order: OrderFromProfile
 )

--- a/src/main/kotlin/payload/response/OrderUpdated.kt
+++ b/src/main/kotlin/payload/response/OrderUpdated.kt
@@ -1,9 +1,9 @@
 package payload.response
 
-import enums.IdOrder
 import kotlinx.serialization.Serializable
+import payload.response.common.OrderFromProfile
 
 @Serializable
 data class OrderUpdated private constructor(
-	val order_id: IdOrder
+	val order: OrderFromProfile
 )

--- a/src/main/kotlin/payload/response/OwnOrders.kt
+++ b/src/main/kotlin/payload/response/OwnOrders.kt
@@ -1,9 +1,9 @@
 package payload.response
 
-import payload.response.common.Order
+import payload.response.common.OrderFromProfile
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class OwnOrders private constructor(
-	val orders: List<Order>
+	val orders: List<OrderFromProfile>
 )

--- a/src/main/kotlin/payload/response/UserOrders.kt
+++ b/src/main/kotlin/payload/response/UserOrders.kt
@@ -1,10 +1,10 @@
 package payload.response
 
-import payload.response.common.Order
+import payload.response.common.OrderFromProfile
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class UserOrders private constructor(
-	val buy_orders: List<Order>,
-	val sell_orders: List<Order>
+	val buy_orders: List<OrderFromProfile>,
+	val sell_orders: List<OrderFromProfile>
 )

--- a/src/main/kotlin/payload/response/common/Order.kt
+++ b/src/main/kotlin/payload/response/common/Order.kt
@@ -48,7 +48,7 @@ data class OrderFromProfile private constructor(
 	override val visible: Boolean,
 	override val mod_rank: Int? = null,
 
-	val item: Item.Item.SetItem?,
+	val item: Item.Item.SetItem,
 ) : Order()
 
 @Serializable
@@ -64,8 +64,8 @@ data class OrderFromProfileStatistics private constructor(
 	override val visible: Boolean,
 	override val mod_rank: Int? = null,
 
-	val item: Item.Item.SetItem?,
-	val closed_date: Instant? //missing if not closed
+	val item: Item.Item.SetItem,
+	val closed_date: Instant
 ) : Order()
 
 @Serializable
@@ -81,5 +81,5 @@ data class OrderFromClosure private constructor(
 	override val visible: Boolean,
 	override val mod_rank: Int? = null,
 
-	val item: IdItem?
+	val item: IdItem
 ) : Order()

--- a/src/main/kotlin/payload/response/common/Order.kt
+++ b/src/main/kotlin/payload/response/common/Order.kt
@@ -6,18 +6,80 @@ import kotlinx.serialization.*
 import payload.response.*
 
 @Serializable
-data class Order private constructor(
-	val creation_date: Instant,
-	val id: IdOrder,
-	val last_update: Instant,
-	val order_type: OrderType,
-	val platform: Platform,
-	val platinum: Double, //sometimes there's .0 at the end. wtf KycKyc
-	val quantity: Int,
-	val region: Region,
-	val visible: Boolean,
-	val mod_rank: Int? = null, //missing if not a mod
-	val item: Item.Item.SetItem? = null, //missing if specified in request
-	val user: UserShort? = null, //missing if specified in request
-	val closed_date: Instant? = null //missing if not closed
-)
+sealed class Order {
+	abstract val creation_date: Instant
+	abstract val id: IdOrder
+	abstract val last_update: Instant
+	abstract val order_type: OrderType
+	abstract val platform: Platform
+	abstract val platinum: Float //sometimes there's .0 at the end. wtf KycKyc
+	abstract val quantity: Int
+	abstract val region: Region
+	abstract val visible: Boolean
+	abstract val mod_rank: Int? //missing if not a mod
+}
+
+@Serializable
+data class OrderFromItem private constructor(
+	override val creation_date: Instant,
+	override val id: IdOrder,
+	override val last_update: Instant,
+	override val order_type: OrderType,
+	override val platform: Platform,
+	override val platinum: Float,
+	override val quantity: Int,
+	override val region: Region,
+	override val visible: Boolean,
+	override val mod_rank: Int? = null, //missing if not a mod
+
+	val user: UserShort? = null //missing if specified in request
+) : Order()
+
+@Serializable
+data class OrderFromProfile private constructor(
+	override val creation_date: Instant,
+	override val id: IdOrder,
+	override val last_update: Instant,
+	override val order_type: OrderType,
+	override val platform: Platform,
+	override val platinum: Float,
+	override val quantity: Int,
+	override val region: Region,
+	override val visible: Boolean,
+	override val mod_rank: Int? = null,
+
+	val item: Item.Item.SetItem?,
+) : Order()
+
+@Serializable
+data class OrderFromProfileStatistics private constructor(
+	override val creation_date: Instant,
+	override val id: IdOrder,
+	override val last_update: Instant,
+	override val order_type: OrderType,
+	override val platform: Platform,
+	override val platinum: Float,
+	override val quantity: Int,
+	override val region: Region,
+	override val visible: Boolean,
+	override val mod_rank: Int? = null,
+
+	val item: Item.Item.SetItem?,
+	val closed_date: Instant? //missing if not closed
+) : Order()
+
+@Serializable
+data class OrderFromClosure private constructor(
+	override val creation_date: Instant,
+	override val id: IdOrder,
+	override val last_update: Instant,
+	override val order_type: OrderType,
+	override val platform: Platform,
+	override val platinum: Float,
+	override val quantity: Int,
+	override val region: Region,
+	override val visible: Boolean,
+	override val mod_rank: Int? = null,
+
+	val item: IdItem?
+) : Order()

--- a/src/test/kotlin/ApiTest.kt
+++ b/src/test/kotlin/ApiTest.kt
@@ -453,7 +453,7 @@ class ApiTest {
 					)
 				)
 			}
-			orderId = orderUpdated.order_id
+			orderId = orderUpdated.order.id
 		}
 
 		@Test


### PR DESCRIPTION
split Order into 4 subclasses to represent payloads more accurately and cut down on nullability (see #8)

fixes #44