### PR TITLE
add missing Lich search params

### DIFF
--- a/src/main/kotlin/payload/common/AuctionItem.kt
+++ b/src/main/kotlin/payload/common/AuctionItem.kt
@@ -33,7 +33,7 @@ data class AuctionItemRiven(
 data class AuctionItemLich(
 	override val weapon_url_name: ItemUrlName,
 	val element: Element,
-	val damage: Float,
+	val damage: Int,
 	val having_ephemera: Boolean,
 	val quirk: Quirk? = null
 ) : AuctionItem()

--- a/src/main/kotlin/payload/request/AuctionSearch.kt
+++ b/src/main/kotlin/payload/request/AuctionSearch.kt
@@ -16,7 +16,9 @@ data class AuctionSearchLich(
 	override val sort_by: SortingStyleLich?,
 	override val weapon_url_name: ItemUrlName?,
 	val element: Element?,
-	val having_ephemera: Boolean
+	val having_ephemera: Boolean,
+	val damage_min: Int,
+	val damage_max: Int,
 ) : AuctionSearch(AuctionType.lich)
 
 @Serializable

--- a/src/test/kotlin/ApiTest.kt
+++ b/src/test/kotlin/ApiTest.kt
@@ -290,7 +290,9 @@ class ApiTest {
 						SortingStyleLich.damage_desc,
 						"kuva_bramma",
 						Element.cold,
-						true
+						true,
+						25,
+						60
 					)
 				)
 			}


### PR DESCRIPTION
closes #52

- added damage_min and damage_max
- ephemera is implicit from `element` + `having_ephemera`
- quirks already got added in #54
- fixes a mistyping (damage was `Float` isntead of `Int`)